### PR TITLE
Fix small spelling mistake.

### DIFF
--- a/cli/help.lisp
+++ b/cli/help.lisp
@@ -24,7 +24,7 @@ hermes online help: <https://github.com/ralt/hermes/issues>
   (declare (ignore args))
   (format t "usage: hermes write <device> <user>
 
-Transform a device in an hermes device for a user.
+Transform a device into a hermes device for a user.
 
 /!\\ WARNING /!\\
 

--- a/cli/write.lisp
+++ b/cli/write.lisp
@@ -5,7 +5,7 @@
      do (write-byte byte stream)))
 
 (defcommand *root-commands* write (args)
-  "transforms a device in an hermes device"
+  "transforms a device into a hermes device"
   (unless args
     (error 'argument-error :text "Missing argument: device"))
   (when (< (length args) 2)


### PR DESCRIPTION
> [...] device **in** **a** hermes device [...]

"In" should be "into", and "an" is only used before "h" [if it's a silent h](http://english.stackexchange.com/questions/629/when-should-i-use-a-versus-an-in-front-of-a-word-beginning-with-the-letter-h).
